### PR TITLE
Metaserver statistics writer

### DIFF
--- a/rexfw/remasters/__init__.py
+++ b/rexfw/remasters/__init__.py
@@ -11,6 +11,10 @@ from rexfw.remasters.requests import DumpSamplesRequest, SendStatsRequest
 
 from abc import abstractmethod
 
+## TODO: this probably shouldn't be here...
+from collections import namedtuple
+RESwapStats = namedtuple('RESwapStats', 'accepted works heats')
+
 
 class ExchangeMaster(object):
 
@@ -239,10 +243,6 @@ class ExchangeMaster(object):
         :param step: the sampling step at which the swaps were performed
         :type step: int
         '''
-
-        ## TODO: this shouldn't be here...
-        from collections import namedtuple
-        RESwapStats = namedtuple('RESwapStats', 'accepted works heats')
         
         for j, (replica1, replica2, _) in enumerate(swap_list):
             stats = RESwapStats(results[j][0], results[j][1], results[j][2])

--- a/rexfw/statistics/writers/__init__.py
+++ b/rexfw/statistics/writers/__init__.py
@@ -9,6 +9,21 @@ import sys
 from abc import abstractmethod
 
 
+def sort_mcmc_quantities(quantities):
+    # for MCMC statistics, there is only one origin, which is
+    # a single replica (as compared to swap moves). So we sort by
+    # the replica index of the first and only entry of origins.
+    def key(x): return int(list(x.origins)[0][len('replica'):])
+    return sorted(quantities, key=key)
+
+
+def sort_re_quantities(quantities):
+    # for swap acceptance rates, origins is a list with of the form
+    # ['replica1', 'replica2']. We thus sort by the smaller replica index.
+    def key(x): return min([int(y[len('replica'):]) for y in x.origins])
+    return sorted(quantities, key=key)
+    
+
 class AbstractStatisticsWriter(object):
 
     def __init__(self, variables_to_write=[], quantities_to_write=[]):
@@ -192,8 +207,7 @@ class StandardConsoleMCMCStatisticsWriter(ConsoleStatisticsWriter):
 
     def _sort_quantities(self, quantities):
 
-        return sorted(quantities,
-                      key=lambda x: int(list(x.origins)[0][len('replica'):]))
+        return sort_mcmc_quantities(quantities)
     
     def _write_quantity_class_header(self, quantity):
         
@@ -228,11 +242,7 @@ class StandardConsoleREStatisticsWriter(ConsoleStatisticsWriter):
         self._outstream.write('{:<10} {:>16}: '.format('RE', 'acceptance rate'))
 
     def _sort_quantities(self, quantities):
-
-        # for swap acceptance rates, origins is a list with of the form
-        # ['replica1', 'replica2']. We thus sort by the smaller replica index.
-        def key(x): return min([int(y[len('replica'):]) for y in x.origins])
-        return sorted(quantities, key=key)
+        return sort_re_quantities(quantities)
     
     def _write_step_header(self, step):
         pass
@@ -312,12 +322,7 @@ class StandardFileMCMCStatisticsWriter(AbstractFileStatisticsWriter):
         self._outstream.write('{}\t'.format(step))
 
     def _sort_quantities(self, quantities):
-
-        # for MCMC statistics, there is only one origin, which is
-        # a single replica (as compared to swap moves). So we sort by
-        # the replica index of the first and only entry of origins.
-        def key(x): return int(list(x.origins)[0][len('replica'):])
-        return sorted(quantities, key=key)
+        return sort_mcmc_quantities(quantities)
 
     def _write_quantity_class_header(self, quantity):
         pass
@@ -370,10 +375,8 @@ class StandardFileREStatisticsWriter(AbstractFileStatisticsWriter):
         self._outstream.write('{}\t'.format(step))
 
     def _sort_quantities(self, quantities):
-
-        return sorted(quantities, key=lambda x: min([int(y[len('replica'):]) 
-                                                     for y in x.origins]))
-
+        return sort_re_quantities(quantities)
+    
     def _write_quantity_class_header(self, class_name):
         pass
 

--- a/rexfw/statistics/writers/__init__.py
+++ b/rexfw/statistics/writers/__init__.py
@@ -11,12 +11,9 @@ from abc import abstractmethod
 
 class AbstractStatisticsWriter(object):
 
-    def __init__(self, separator, variables_to_write=[], quantities_to_write=[]):
+    def __init__(self, variables_to_write=[], quantities_to_write=[]):
         '''
-        Base class for classes which write sampling statistics to stdout, files, ...
-
-        :param str separator: separator string separating values of different
-                              quantities in written output
+        Base class for classes which write sampling statistics.
 
         :param variables_to_write: list of sampling variable names for which to
                                    write statistics
@@ -26,7 +23,6 @@ class AbstractStatisticsWriter(object):
                                     write statistics
         :type quantities_to_write: list of :class:`.LoggedQuantity`
         '''
-        self._separator = separator
         self.variables_to_write = variables_to_write
         self.quantities_to_write = quantities_to_write
 
@@ -40,7 +36,28 @@ class AbstractStatisticsWriter(object):
         :type elements: list of :class:`.LoggedQuantity`
         '''
         pass
-    
+
+
+class AbstractTextStatisticsWriter(AbstractStatisticsWriter):
+    def __init__(self, separator, variables_to_write=[], quantities_to_write=[]):
+        '''
+        Base class for classes which write sampling statistics to some
+        text-based output, for example, stdout or a file.
+
+        :param str separator: separator string separating values of different
+                              quantities in written output
+
+        :param variables_to_write: list of sampling variable names for which to
+                                   write statistics
+        :type variables_to_write: list of str
+
+        :param quantities_to_write: list of :class:`.LoggedQuantity` objects for which to
+                                    write statistics
+        :type quantities_to_write: list of :class:`.LoggedQuantity`
+        '''
+        super().__init__(variables_to_write, quantities_to_write)
+        self._separator = separator
+
     def _write_single_quantity_stats(self, elements):
         '''
         Writes a single line to stdout / file, e.g., all sampler step sizes
@@ -53,9 +70,8 @@ class AbstractStatisticsWriter(object):
         for e in self._sort_quantities(elements):
             self._outstream.write(self._format(e) + self._separator)
         self._outstream.write('\n')
-           
-
-class ConsoleStatisticsWriter(AbstractStatisticsWriter):
+        
+class ConsoleStatisticsWriter(AbstractTextStatisticsWriter):
 
     def __init__(self, variables_to_write=[], quantities_to_write=[]):
         '''
@@ -220,7 +236,7 @@ class StandardConsoleREStatisticsWriter(ConsoleStatisticsWriter):
         pass
  
         
-class AbstractFileStatisticsWriter(AbstractStatisticsWriter):
+class AbstractFileStatisticsWriter(AbstractTextStatisticsWriter):
 
     def __init__(self, filename, variables_to_write=[], quantities_to_write=[]):
         '''
@@ -367,7 +383,7 @@ class StandardFileREStatisticsWriter(AbstractFileStatisticsWriter):
         self._write_single_quantity_stats(quantities)
 
 
-class StandardFileREWorksStatisticsWriter(AbstractStatisticsWriter):
+class StandardFileREWorksStatisticsWriter(AbstractTextStatisticsWriter):
 
     def __init__(self, outfolder):
         '''
@@ -388,7 +404,7 @@ class StandardFileREWorksStatisticsWriter(AbstractStatisticsWriter):
                 dump(e.values, opf)
 
 
-class StandardFileREHeatsStatisticsWriter(AbstractStatisticsWriter):
+class StandardFileREHeatsStatisticsWriter(AbstractTextStatisticsWriter):
     '''
     Writes heats produced during replica exchange swap trajectories to a file.        
 

--- a/rexfw/statistics/writers/__init__.py
+++ b/rexfw/statistics/writers/__init__.py
@@ -6,7 +6,7 @@ ATTENTION: some of these classes expect replica objects to be named replica1, re
 
 import sys
 
-from abc import abstractmethod
+from abc import abstractmethod, ABCMeta
 
 
 def sort_mcmc_quantities(quantities):
@@ -24,8 +24,8 @@ def sort_re_quantities(quantities):
     return sorted(quantities, key=key)
     
 
-class AbstractStatisticsWriter(object):
-
+class AbstractStatisticsWriter(metaclass=ABCMeta):
+    
     def __init__(self, variables_to_write=[], quantities_to_write=[]):
         '''
         Base class for classes which write sampling statistics.

--- a/rexfw/statistics/writers/__init__.py
+++ b/rexfw/statistics/writers/__init__.py
@@ -229,8 +229,10 @@ class StandardConsoleREStatisticsWriter(ConsoleStatisticsWriter):
 
     def _sort_quantities(self, quantities):
 
-        return sorted(quantities, key=lambda x: min([int(y[len('replica'):]) 
-                                                for y in x.origins]))
+        # for swap acceptance rates, origins is a list with of the form
+        # ['replica1', 'replica2']. We thus sort by the smaller replica index.
+        def key(x): return min([int(y[len('replica'):]) for y in x.origins])
+        return sorted(quantities, key=key)
     
     def _write_step_header(self, step):
         pass
@@ -311,7 +313,11 @@ class StandardFileMCMCStatisticsWriter(AbstractFileStatisticsWriter):
 
     def _sort_quantities(self, quantities):
 
-        return sorted(quantities, key=lambda x: int(list(x.origins)[0][len('replica'):]))
+        # for MCMC statistics, there is only one origin, which is
+        # a single replica (as compared to swap moves). So we sort by
+        # the replica index of the first and only entry of origins.
+        def key(x): return int(list(x.origins)[0][len('replica'):])
+        return sorted(quantities, key=key)
 
     def _write_quantity_class_header(self, quantity):
         pass

--- a/rexfw/statistics/writers/http.py
+++ b/rexfw/statistics/writers/http.py
@@ -1,0 +1,115 @@
+'''
+Statistics writer classes which send statistics via HTTP to
+a server.
+'''
+import requests
+import json
+from abc import abstractmethod
+
+from rexfw.statistics.writers import AbstractStatisticsWriter
+
+
+class LoggingError(Exception):
+    def __init__(self, response):
+        msg = ("Sending sampling statistics to URL {} failed. "
+               "Response content is as follows:\n{}")
+        super().__init__(msg.format(response.request.url,
+                                    response.content))
+
+
+class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
+
+    def __init__(self, http_endpoint, variables_to_write=[],
+                 quantities_to_write=[]):
+        '''
+        Base class for classes which write sampling statistics
+        to HTTP endpoints.
+
+        :param http_endpoint: IP address / host name of HTTP endpoint
+        :type http_endpoint: str
+
+        :param variables_to_write: list of sampling variable names for which to
+                                   write statistics
+        :type variables_to_write: list of str
+
+        :param quantities_to_write: list of :class:`.LoggedQuantity` objects for which to
+                                    write statistics
+        :type quantities_to_write: list of :class:`.LoggedQuantity`
+        '''
+        super().__init__(variables_to_write, quantities_to_write)
+        self._http_endpoint = http_endpoint
+
+
+    @abstractmethod
+    def _quantities_to_JSONable_dict(self, quantity_name, quantities):
+        '''
+        Turns a list of :class:`.Quantity objects into some Python object that
+        can be serialized via JSON.
+
+        :param quantity_name: str
+        :param quantities: list of :class:`Quantity objects
+        '''
+        value_list = [self._sanitize_value(x.current_value)
+                      for x in quantities]
+        
+        return {quantity_name: value_list}
+
+    @abstractmethod
+    def _sort_quantities(self, quantities):
+        pass
+
+    def _sanitize_value(self, value):
+        '''
+        TODO: this might need to be customizable, e.g., to replace
+        None value for an acceptance rate by 0.0
+        '''
+        return value
+    
+    def write(self, step, elements):
+        '''
+        Sends values of quantities in elements for a given
+        step to the HTTP endpoint.
+
+        :param int step: sampling step
+        :param elements: list of quantities to write
+        :type elements: list of :class:`.LoggedQuantity`
+        '''
+
+        metadata = {'mcmc_step': step}
+        all_data = metadata
+        for quantity_name in set([quantity.name
+                                  for quantity in elements]):
+            filtered_quantities = elements.select(name=quantity_name)
+            # sorted_quantities = map(self._sort_quantities, filtered_quantities)
+            data = self._quantities_to_JSONable_dict(quantity_name,
+                                                     filtered_quantities)
+            all_data.update(**data)
+
+        response = requests.post(self._http_endpoint,
+                                 json=json.dumps(all_data))
+        if not response.ok:
+            raise LoggingError(response)
+
+
+class REHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
+    def _sort_quantities(self, quantities):
+        '''
+        TODO: totally copy & pasted from StandardConsoleREStatisticsWriter
+        '''
+        # for swap statistics such as the acceptance rates, origins is a list
+        # of the form ['replica1', 'replica2']. We thus sort by the smaller
+        # replica index.
+        def key(x): return min([int(y[len('replica'):]) for y in x.origins])
+        return sorted(quantities, key=key)
+
+
+class MCMCHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
+    def _sort_quantities(self, quantities):
+        '''
+        TODO: totally copy & pasted from StandardFileMCMCStatisticsWriter
+        '''
+        # for MCMC statistics, there is only one origin, which is
+        # a single replica (as compared to swap moves). So we sort by
+        # the replica index of the first and only entry of origins.
+        def key(x): return int(list(x.origins)[0][len('replica'):])
+        return sorted(quantities, key=key)

--- a/rexfw/statistics/writers/http.py
+++ b/rexfw/statistics/writers/http.py
@@ -6,7 +6,9 @@ import requests
 import json
 from abc import abstractmethod
 
-from rexfw.statistics.writers import AbstractStatisticsWriter
+from rexfw.statistics.writers import (AbstractStatisticsWriter,
+                                      sort_mcmc_quantities,
+                                      sort_re_quantities)
 
 
 class LoggingError(Exception):
@@ -18,7 +20,7 @@ class LoggingError(Exception):
 
 
 class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
-
+    _data_prefix = ""
     def __init__(self, http_endpoint, variables_to_write=[],
                  quantities_to_write=[]):
         '''
@@ -76,15 +78,17 @@ class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
         '''
 
         metadata = {'mcmc_step': step}
-        all_data = metadata
+        statistics_data = {}
         for quantity_name in set([quantity.name
                                   for quantity in elements]):
             filtered_quantities = elements.select(name=quantity_name)
-            # sorted_quantities = map(self._sort_quantities, filtered_quantities)
+            sorted_quantities = self._sort_quantities(filtered_quantities)
             data = self._quantities_to_JSONable_dict(quantity_name,
-                                                     filtered_quantities)
-            all_data.update(**data)
-
+                                                     sorted_quantities)
+            statistics_data.update(**data)
+        all_data = {"{}_statistics".format(self._data_prefix): statistics_data}
+        all_data.update(**metadata)
+            
         response = requests.post(self._http_endpoint,
                                  json=json.dumps(all_data))
         if not response.ok:
@@ -92,24 +96,13 @@ class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
 
 
 class REHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
+    _data_prefix = "re_"
+    
     def _sort_quantities(self, quantities):
-        '''
-        TODO: totally copy & pasted from StandardConsoleREStatisticsWriter
-        '''
-        # for swap statistics such as the acceptance rates, origins is a list
-        # of the form ['replica1', 'replica2']. We thus sort by the smaller
-        # replica index.
-        def key(x): return min([int(y[len('replica'):]) for y in x.origins])
-        return sorted(quantities, key=key)
-
+        return sort_re_quantities(quantities)
 
 class MCMCHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
+    _data_prefix = "mcmc_"
+    
     def _sort_quantities(self, quantities):
-        '''
-        TODO: totally copy & pasted from StandardFileMCMCStatisticsWriter
-        '''
-        # for MCMC statistics, there is only one origin, which is
-        # a single replica (as compared to swap moves). So we sort by
-        # the replica index of the first and only entry of origins.
-        def key(x): return int(list(x.origins)[0][len('replica'):])
-        return sorted(quantities, key=key)
+        return sort_mcmc_quantities(quantities)

--- a/rexfw/statistics/writers/http.py
+++ b/rexfw/statistics/writers/http.py
@@ -20,6 +20,8 @@ class LoggingError(Exception):
 
 
 class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
+    # prefix the data key in the JSON to be sent with
+    # something informative in subclasses
     _data_prefix = ""
     def __init__(self, http_endpoint, variables_to_write=[],
                  quantities_to_write=[]):
@@ -41,8 +43,6 @@ class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
         super().__init__(variables_to_write, quantities_to_write)
         self._http_endpoint = http_endpoint
 
-
-    @abstractmethod
     def _quantities_to_JSONable_dict(self, quantity_name, quantities):
         '''
         Turns a list of :class:`.Quantity objects into some Python object that
@@ -57,27 +57,28 @@ class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
         return {quantity_name: value_list}
 
     @abstractmethod
+    def _sanitize_value(self, value):
+        '''
+        Sanitize a quantity's current value, e.g., for an acceptance
+        rate, replace None by 0.0
+
+        :param value: a quantity's current value
+        :type value: could be literally anything
+        '''
+        pass
+    
+    @abstractmethod
     def _sort_quantities(self, quantities):
         pass
 
-    def _sanitize_value(self, value):
+    def _make_data_dict(self, elements):
         '''
-        TODO: this might need to be customizable, e.g., to replace
-        None value for an acceptance rate by 0.0
-        '''
-        return value
-    
-    def write(self, step, elements):
-        '''
-        Sends values of quantities in elements for a given
-        step to the HTTP endpoint.
+        Make a dictionary (which can be serialized to JSON) from the data
+        in elements.
 
-        :param int step: sampling step
         :param elements: list of quantities to write
         :type elements: list of :class:`.LoggedQuantity`
         '''
-
-        metadata = {'mcmc_step': step}
         statistics_data = {}
         for quantity_name in set([quantity.name
                                   for quantity in elements]):
@@ -86,9 +87,26 @@ class AbstractHTTPStatisticsWriter(AbstractStatisticsWriter):
             data = self._quantities_to_JSONable_dict(quantity_name,
                                                      sorted_quantities)
             statistics_data.update(**data)
-        all_data = {"{}_statistics".format(self._data_prefix): statistics_data}
-        all_data.update(**metadata)
-            
+        all_data = {"{}statistics".format(self._data_prefix): statistics_data}
+
+        return all_data
+
+    def _augment_with_metadata(self, all_data, step):
+        all_data['mcmc_step'] = step
+        return all_data
+    
+    def write(self, step, elements):
+        '''
+        Sends values of quantities in elements for a given
+        step to the HTTP endpoint.
+
+        :param step: sampling step
+        :type step: int
+        :param elements: list of quantities to write
+        :type elements: list of :class:`.LoggedQuantity`
+        '''
+        all_data = self._make_data_dict(elements)
+        self._augment_with_metadata(all_data, step)
         response = requests.post(self._http_endpoint,
                                  json=json.dumps(all_data))
         if not response.ok:
@@ -101,8 +119,14 @@ class REHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
     def _sort_quantities(self, quantities):
         return sort_re_quantities(quantities)
 
+    def _sanitize_value(self, value):
+        return 0.0 if value is None else value
+
 class MCMCHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
     _data_prefix = "mcmc_"
     
     def _sort_quantities(self, quantities):
         return sort_mcmc_quantities(quantities)
+
+    def _sanitize_value(self, value):
+        return 0.0 if value is None else value

--- a/rexfw/test/cases/statistics/writers/__init__.py
+++ b/rexfw/test/cases/statistics/writers/__init__.py
@@ -1,14 +1,125 @@
 '''
 '''
-
+import unittest
+from rexfw.remasters import RESwapStats
+from rexfw.samplers.rwmc import RWMCSampleStats
+from rexfw.statistics import FilterableQuantityList
+from rexfw.statistics.logged_quantities import SamplerStepsize
+from rexfw.statistics.averages import REAcceptanceRateAverage
 from rexfw.statistics.writers import AbstractStatisticsWriter
+from rexfw.statistics.writers.http import (AbstractHTTPStatisticsWriter,
+                                           REHTTPStatisticsWriter,
+                                           MCMCHTTPStatisticsWriter)
 
 
 class MockStatisticsWriter(AbstractStatisticsWriter):
-
     def __init__(self):
-
         super(MockStatisticsWriter, self).__init__('8-)')
 
     def write(self, step, elements):
         pass
+
+
+class MockedAbstractHTTPStatisticsWriter(AbstractHTTPStatisticsWriter):
+    _data_prefix = "prefix_"
+
+    def _sort_quantities(self, quantities):
+        return quantities
+
+    def _sanitize_value(self, value):
+        return value
+
+
+def setup_test_writer(writer_class):
+    # little demo of the quantity objects: in the following list, we have
+    # a "normal" logged quantity, the stepsize. It has a fixed value and
+    # its current value only depends on whatever it last was updated with.
+    # The acceptance rate quantity object, on the other hand, is an
+    # averaged logged quantity. It basically keeps a state of the current
+    # average and updates that average, once a new acceptance / rejection
+    # info comes in via the update() method.
+    quantities = [SamplerStepsize('replica22', 'x'),
+                  REAcceptanceRateAverage('replica3', 'replica2')]
+    quantities = FilterableQuantityList(quantities)
+
+    quantities[0].update(123, {'x': RWMCSampleStats(True, 1, 0.1)})
+    quantities[1].update(123, RESwapStats(False, [0.0], [0.0]))
+    # Now, current_value() of quantities[1] is 0.0
+    quantities[1].update(124, RESwapStats(True, [0.0], [0.0]))
+    # But now, it is 0.5. Magic, huh?
+
+    return writer_class("doesntexist", ["myvar", "myothervar"], quantities)
+
+
+class testAbstractHTTPStatisticsWriter(unittest.TestCase):
+
+    def setUp(self):
+        self._writer = setup_test_writer(MockedAbstractHTTPStatisticsWriter)        
+
+    def testQuantitiesToJSONableDict(self):
+        res1 = self._writer._quantities_to_JSONable_dict(
+            'stepsize', [self._writer.quantities_to_write[0]])
+        expected = {'stepsize': [0.1]}
+        self.assertEqual(res1, expected)
+
+        res2 = self._writer._quantities_to_JSONable_dict(
+            'acceptance rate', [self._writer.quantities_to_write[1]])
+        expected = {'acceptance rate': [0.5]}
+        self.assertEqual(res2, expected)
+
+    def testMakeDataDict(self):
+        res1 = self._writer._make_data_dict(
+            FilterableQuantityList(self._writer.quantities_to_write[:2]))
+        expected = {'prefix_statistics':
+                    {'stepsize': [0.1], 'acceptance rate': [0.5]}}
+        self.assertEqual(res1, expected)
+
+        res2 = self._writer._make_data_dict(
+            FilterableQuantityList(self._writer.quantities_to_write[1:]))
+        expected = {'prefix_statistics': {'acceptance rate': [0.5]}}
+        self.assertEqual(res2, expected)
+
+    def testAugmentWithMetadata(self):
+        res = self._writer._augment_with_metadata({'somekey': 42}, 321)
+        expected = {'mcmc_step': 321, 'somekey': 42}
+        self.assertEqual(res, expected)
+
+
+class testREHTTPStatisticsWriter(unittest.TestCase):
+    def setUp(self):
+        self._writer = setup_test_writer(REHTTPStatisticsWriter)
+
+    def testSortQuantities(self):
+        quants = self._writer.quantities_to_write
+        res = self._writer._sort_quantities(quants)
+        expected = [quants[1], quants[0]]
+        self.assertEqual(res, expected)
+
+    def testSanitizeValue(self):
+        res1 = self._writer._sanitize_value(None)
+        expected1 = 0.0
+        self.assertEqual(res1, expected1)
+
+        res2 = self._writer._sanitize_value(0.42)
+        expected2 = 0.42
+        self.assertEqual(res2, expected2)
+
+
+class testMCMCHTTPStatisticsWriter(unittest.TestCase):
+    def setUp(self):
+        self._writer = setup_test_writer(MCMCHTTPStatisticsWriter)
+
+    def testSortQuantities(self):
+        quants = self._writer.quantities_to_write
+        res = self._writer._sort_quantities(quants)
+        expected = [quants[1], quants[0]]
+        self.assertEqual(res, expected)
+
+    def testSanitizeValue(self):
+        res1 = self._writer._sanitize_value(None)
+        expected1 = 0.0
+        self.assertEqual(res1, expected1)
+
+        res2 = self._writer._sanitize_value(0.42)
+        expected2 = 0.42
+        self.assertEqual(res2, expected2)

--- a/rexfw/test/test_statistics_server.py
+++ b/rexfw/test/test_statistics_server.py
@@ -1,0 +1,9 @@
+from flask import Flask
+app = Flask(__name__)
+from flask import request
+
+@app.route('/', methods=['POST'])
+def print_request():
+    print(request.json)
+
+    return "ok"

--- a/shell.nix
+++ b/shell.nix
@@ -9,8 +9,8 @@ let
     installCheckPhase = ''
       cd rexfw/test && python run_tests.py
     '';
-    buildInputs = [ numpy ];
-    propagatedBuildInputs = buildInputs ++ [ mpi4py openmpi ];
+    buildInputs = [ numpy requests ];
+    propagatedBuildInputs = buildInputs ++ [ mpi4py openmpi requests ];
   };
 in
   pkgs.mkShell {


### PR DESCRIPTION
This closes an [issue](https://github.com/tweag/resaas/issues/7) over in the `resaas` repository.
The new statistics writer classes send a JSON with the following structure:
```
{
	"mcmc_step": 1234,
	"mcmc_statistics": {"acceptance rate": [0.23, 0.45, 0.67], "stepsize": [1.0, 2.0, 3.0, 4.0]}
}
```
(for local sampling statistics)
or
```
{
	"mcmc_step": 1234,
	"re_statistics": {"acceptance rate": [0.23, 0.45]}
}
```
where `mcmc_acceptance_rates` and `mcmc_stepsizes` could be something else, too. In short, there will 
always be a `mcmc_step` field and one or more other quantities, for which (possibly nested) values are given.