### PR TITLE
Add gradient to pdf interface and normal dist implementation

### DIFF
--- a/rexfw/pdfs/__init__.py
+++ b/rexfw/pdfs/__init__.py
@@ -11,3 +11,7 @@ class AbstractPDF(object):
     @abstractmethod
     def log_prob(self, x):
         pass
+
+    @abstractmethod
+    def log_prob_gradient(self, x):
+        pass

--- a/rexfw/pdfs/normal.py
+++ b/rexfw/pdfs/normal.py
@@ -14,3 +14,7 @@ class Normal(AbstractPDF):
     def log_prob(self, x):
         
         return -0.5 * (x - self.mu) ** 2 / self.sigma / self.sigma
+
+    def log_prob_gradient(self, x):
+
+        return -(x - self.mu) / self.sigma / self.sigma


### PR DESCRIPTION
Extend the `Pdf` interface with the gradient of the log-probability.