### PR TITLE
Write bare energies instead of tempered ones

### DIFF
--- a/rexfw/pdfs/__init__.py
+++ b/rexfw/pdfs/__init__.py
@@ -11,3 +11,8 @@ class AbstractPDF(object):
     @abstractmethod
     def log_prob(self, x):
         pass
+
+    def bare_log_prob(self, x):
+        # TODO: this is only to make the normal.py example script and possibly
+        # tests happy
+        return self.log_prob(x)

--- a/rexfw/replicas/__init__.py
+++ b/rexfw/replicas/__init__.py
@@ -353,10 +353,10 @@ class Replica(object):
         
     def get_energy(self, state):
         '''
-        Calculates replica energy (negative log-probability) for a given state
+        Calculates replica energy (untempered negative log-probability) for a given state
 
         :param state: state for which to evaluate the negative log-probability of
                       the replica's PDF
         :type state: depends on your application
         '''
-        return -self.pdf.log_prob(state)
+        return -self.pdf.bare_log_prob(state)


### PR DESCRIPTION
Closes https://github.com/tweag/resaas/issues/83.
This writes out bare (untempered) energies instead of full negative log-probabilities, as required for histogram reweighting.
For that, it expects the pdf object passed to the `Replica` class to have a method `bare_log_prob`.
This only works for the Boltzmann ensemble or other one-parameter families. We should at one point generalize this to something universal, like have a `dump_features` function and a Pdf object with a method `bare_features` which could then return, e.g., a `dict` with a `prior` and a `likelihood` entry.