### PR TITLE
Add stepsize adaption heuristic to RWMC sampler

### DIFF
--- a/rexfw/samplers/rwmc.py
+++ b/rexfw/samplers/rwmc.py
@@ -34,9 +34,9 @@ class RWMCSampler(AbstractSampler):
 
     def _adapt_stepsize(self):
         if self._last_move_accepted:
-            self.stepsize *= self.adaption_downrate
-        else:
             self.stepsize *= self.adaption_uprate
+        else:
+            self.stepsize *= self.adaption_downrate
 
     def sample(self):
 


### PR DESCRIPTION
This adds the "timestep" adaption to the RWMC test sampler.
It's all a mixup between stepsize and timestep here, but we can fix this at some point. Probably all timestep-something things should be called stepsize, because it's more universal and still appropriate to HMC.