### PR TITLE
Make RWMC sampler work with multidimensional states

### DIFF
--- a/rexfw/samplers/rwmc.py
+++ b/rexfw/samplers/rwmc.py
@@ -41,7 +41,8 @@ class RWMCSampler(AbstractSampler):
     def sample(self):
 
         E_old = -self.pdf.log_prob(self.state)
-        proposal = self.state + np.random.uniform(low=-self.stepsize, high=self.stepsize)
+        proposal = self.state + np.random.uniform(
+            low=-self.stepsize, high=self.stepsize, size=len(self.state))
         E_new = -self.pdf.log_prob(proposal)
 
         accepted = np.log(np.random.random()) < -(E_new - E_old)


### PR DESCRIPTION
This improves the RWMC sampler so that multidimensional distributions can be sampled correctly.
What happened before was that the proposal state was obtained by adding exactly the same random number to all components of the state vector, which obviously doesn't work well.