### PR TITLE
Log negative log prob

### DIFF
--- a/rexfw/convenience/__init__.py
+++ b/rexfw/convenience/__init__.py
@@ -108,7 +108,7 @@ def create_default_stats_elements(replica_names, variable_name):
     re_pacc_avgs = create_default_RE_averages(replica_names)
     stepsizes = create_default_stepsizes(replica_names, variable_name)
     neg_log_probs = [NegativeLogProb(replica_name, variable_name)
-                     for replica_name in replicas_names]
+                     for replica_name in replica_names]
     
     return mcmc_pacc_avgs, re_pacc_avgs, stepsizes, neg_log_probs
 

--- a/rexfw/pdfs/normal.py
+++ b/rexfw/pdfs/normal.py
@@ -1,6 +1,7 @@
 '''
 A normal distribution as an example for the PDF interface
 '''
+import numpy as np
 
 from rexfw.pdfs import AbstractPDF
 
@@ -13,4 +14,4 @@ class Normal(AbstractPDF):
 
     def log_prob(self, x):
         
-        return -0.5 * (x - self.mu) ** 2 / self.sigma / self.sigma
+        return -0.5 * np.sum((x - self.mu) ** 2) / self.sigma / self.sigma

--- a/rexfw/samplers/rwmc.py
+++ b/rexfw/samplers/rwmc.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from rexfw.samplers import AbstractSampler
 
 
-RWMCSampleStats = namedtuple('RWMCSampleStats', 'accepted total stepsize')
+RWMCSampleStats = namedtuple('RWMCSampleStats', 'accepted total stepsize neg_log_prob')
 
 
 class RWMCSampler(AbstractSampler):
@@ -29,8 +29,9 @@ class RWMCSampler(AbstractSampler):
     @property
     def last_draw_stats(self):
 
-        return {self.variable_name: RWMCSampleStats(self._last_move_accepted, 
-                                                    self._n_moves, self.stepsize)}
+        return {self.variable_name: RWMCSampleStats(
+            self._last_move_accepted, self._n_moves, self.stepsize,
+            -self.pdf.log_prob(self.state))}
 
     def _adapt_stepsize(self):
         if self._last_move_accepted:

--- a/rexfw/statistics/logged_quantities.py
+++ b/rexfw/statistics/logged_quantities.py
@@ -106,7 +106,32 @@ class SamplerStepsize(LoggedQuantity):
 
         return '{} {} {}: {}'.format(self.origins[0], self.variable_name, 
                                      self.name,self.current_value)
-        
+
+
+class NegativeLogProb(LoggedQuantity):
+
+    def __init__(self, replica, variable_name):
+        '''
+        Logged quantity which tracks negative log probabilties of a sampler
+
+        :param str replica: the name of the replica whose negative log-prob is being
+                            tracked
+        :param str variable_name: the name of the sampling variable associated with the
+                                  negative log-prob
+        '''
+
+        super(NegativeLogProb, self).__init__([replica], ['neg_log_prob'], 'neg_log_prob',
+                                              variable_name)
+
+    def _get_value(self, stats):
+
+        return stats[self.variable_name].neg_log_prob
+
+    def __repr__(self):
+
+        return '{} {} {}: {}'.format(self.origins[0], self.variable_name, 
+                                     self.name, self.current_value)
+
 
 class REWorks(LoggedQuantity):
 

--- a/rexfw/statistics/writers/graphite.py
+++ b/rexfw/statistics/writers/graphite.py
@@ -54,7 +54,7 @@ class GraphiteREStatisticsWriter(GraphiteStatisticsWriter):
         list_of_stats_tuples = []
         for e in elements:
             if e.name == "acceptance rate" and len(e.origins) == 2:
-                path = self.job_name + "." + "_".join(e.origins) + "." + "acceptance_rate.re"
+                path = self.job_name + "." + "_".join(e.origins) + "." + "acceptance_rate"
                 list_of_stats_tuples.append((path, (timestamp, e.current_value)))
         return list_of_stats_tuples
 
@@ -67,7 +67,7 @@ class GraphiteMCMCStatisticsWriter(GraphiteStatisticsWriter):
             log_this = False
             path_template = self.job_name + "." + e.origins[0] + ".{}"
             if e.name == "acceptance rate" and len(e.origins) == 1:
-                path = path_template.format("acceptance_rate.local")
+                path = path_template.format("acceptance_rate")
                 log_this = True
             if e.name == "stepsize":
                 path = path_template.format("stepsize")
@@ -75,7 +75,6 @@ class GraphiteMCMCStatisticsWriter(GraphiteStatisticsWriter):
             if e.name == "neg_log_prob":
                 path = path_template.format("negative_log_prob")
                 log_this = True
-
             if log_this:
-                list_of_stats_tuples.append((path, (timestamp, e.current_value)))
+                list_of_stats_tuples.append((path, (timestamp, float(e.current_value))))
         return list_of_stats_tuples

--- a/rexfw/statistics/writers/graphite.py
+++ b/rexfw/statistics/writers/graphite.py
@@ -64,11 +64,18 @@ class GraphiteMCMCStatisticsWriter(GraphiteStatisticsWriter):
         timestamp = -1
         list_of_stats_tuples = []
         for e in elements:
+            log_this = False
+            path_template = self.job_name + "." + e.origins[0] + ".{}"
             if e.name == "acceptance rate" and len(e.origins) == 1:
-                path = self.job_name + "." + e.origins[0] + "." + "acceptance_rate.local"
-                list_of_stats_tuples.append((path, (timestamp, e.current_value)))
+                path = path_template.format("acceptance_rate.local")
+                log_this = True
             if e.name == "stepsize":
-                path = self.job_name + "." + "stepsize"
+                path = path_template.format("stepsize")
+                log_this = True
+            if e.name == "neg_log_prob":
+                path = path_template.format("negative_log_prob")
+                log_this = True
 
+            if log_this:
                 list_of_stats_tuples.append((path, (timestamp, e.current_value)))
         return list_of_stats_tuples


### PR DESCRIPTION
This adds the negative log-probability as an additional sampler statistic to log. It would be nicer if the replicas were doing this and furthermore this unnecessarily evaluates the log-prob, but that's all okay, I think.
This closes the rexfw part of https://github.com/tweag/resaas/issues/168 and also fixes https://github.com/tweag/resaas/issues/175 and possibly also https://github.com/tweag/resaas/issues/174.